### PR TITLE
Add multicolor effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ Currently this will imply the `-a` flag being used for the missing setting. I
 plan on also having the option to reuse the current color/effect, if the
 argument is missing, in the future.
 
+#### Effects
+Effects are listed in
+[`razer_cli/util.py`](https://github.com/LoLei/razer-cli/blob/master/razer_cli/util.py).
+Some of the built-in effects or not implemented yet. If such an effect is
+chosen, a notice will be logged. There are also custom effects that do not exist
+normally, such as `multicolor`, which is described in the same file.
+
 #### Other symbiosis tools
 * [`wpgtk`](https://github.com/deviantfero/wpgtk)
 * [`Chameleon`](https://github.com/GideonWolfe/Chameleon)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ argument is missing, in the future.
 #### Effects
 Effects are listed in
 [`razer_cli/settings.py`](https://github.com/LoLei/razer-cli/blob/master/razer_cli/settings.py).
+The effects that are supported per device can be listed with `razer-cli -l[l]`.
 Some of the built-in effects or not implemented yet. If such an effect is
 chosen, a notice will be logged. There are also custom effects that do not exist
 normally, such as `multicolor`, which is described in the same file.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Some of the built-in effects or not implemented yet. If such an effect is
 chosen, a notice will be logged. There are also custom effects that do not exist
 normally, such as `multicolor`, which is described in the same file.
 
+Here's a showcase of that effect:
+<p align="center">
+  <img src="https://raw.githubusercontent.com/LoLei/razer-cli/master/images/randomshowcase.gif">
+</p>
+
 #### Other symbiosis tools
 * [`wpgtk`](https://github.com/deviantfero/wpgtk)
 * [`Chameleon`](https://github.com/GideonWolfe/Chameleon)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ argument is missing, in the future.
 
 #### Effects
 Effects are listed in
-[`razer_cli/util.py`](https://github.com/LoLei/razer-cli/blob/master/razer_cli/util.py).
+[`razer_cli/settings.py`](https://github.com/LoLei/razer-cli/blob/master/razer_cli/settings.py).
 Some of the built-in effects or not implemented yet. If such an effect is
 chosen, a notice will be logged. There are also custom effects that do not exist
 normally, such as `multicolor`, which is described in the same file.

--- a/razer_cli/razer_cli.py
+++ b/razer_cli/razer_cli.py
@@ -330,8 +330,6 @@ def read_args():
 def main():
     """ Main entry point of the app """
 
-    print('DEVELOPMENT BUILD - TODO REMOVE THIS STATEMENT')
-
     read_args()
 
     # -------------------------------------------------------------------------

--- a/razer_cli/razer_cli.py
+++ b/razer_cli/razer_cli.py
@@ -365,8 +365,11 @@ def main():
 
     # Do below only if dry run is not specified
     if args.automatic or args.effect or args.color:
-        set_effect_to_all_devices(device_manager, args.effect[0], color,
-                                  args.effect[1:])
+        if args.effect:
+            set_effect_to_all_devices(device_manager, args.effect[0], color,
+                                      args.effect[1:])
+        else:
+            set_effect_to_all_devices(device_manager, args.effect, color)
 
     if args.dpi:
         set_dpi(device_manager)

--- a/razer_cli/razer_cli.py
+++ b/razer_cli/razer_cli.py
@@ -235,18 +235,17 @@ def set_effect_to_device(device, effect, color, effect_args=[]):
         colors_to_dist = []
         if effect_args:
             colors_to_dist = [util.hex_to_decimal(c) for c in effect_args]
+        # Use random colors if no colors are supplied
+        else:
+            colors_to_dist = [util.get_random_color_rgb() for _ in
+                              range(cols*rows)]
 
         try:
             counter = 0
             for row in range(rows):
                 for col in range(cols):
-                    if colors_to_dist:
-                        device.fx.advanced.matrix.set(row, col,
-                                colors_to_dist[counter % len(colors_to_dist)])
-                    # Use random colors if no colors are supplied
-                    else:
-                        device.fx.advanced.matrix.set(row, col,
-                                util.get_random_color_rgb())
+                    device.fx.advanced.matrix.set(row, col,
+                            colors_to_dist[counter % len(colors_to_dist)])
                     counter += 1
             # device.fx.advanced.draw_fb_or()
             device.fx.advanced.draw()

--- a/razer_cli/settings.py
+++ b/razer_cli/settings.py
@@ -32,5 +32,9 @@ EFFECTS = [
 
 # These effects are not built-in the driver
 CUSTOM_EFFECTS = [
-        'multicolor'  # Multiple colors - For now a random color for each key
+        # Multiple colors - Either no additional argument and a random color is
+        # chosen for each key, or colors can be supplied which are then evenly
+        # distributed, for example razer-cli -v -e multicolor ff0000 00ff00
+        # 0000ff
+        'multicolor'
 ]

--- a/razer_cli/settings.py
+++ b/razer_cli/settings.py
@@ -34,7 +34,7 @@ EFFECTS = [
 CUSTOM_EFFECTS = [
         # Multiple colors - Either no additional argument and a random color is
         # chosen for each key, or colors can be supplied which are then evenly
-        # distributed, for example razer-cli -v -e multicolor ff0000 00ff00
+        # distributed, for example razer-cli -e multicolor ff0000 00ff00
         # 0000ff
         'multicolor'
 ]

--- a/razer_cli/settings.py
+++ b/razer_cli/settings.py
@@ -29,3 +29,8 @@ EFFECTS = [
         'static',
         'wave',
 ]
+
+# These effects are not built-in the driver
+CUSTOM_EFFECTS = [
+        'multicolor'  # Multiple colors - For now a random color for each key
+]

--- a/razer_cli/util.py
+++ b/razer_cli/util.py
@@ -1,6 +1,7 @@
 from razer_cli import settings
 import os
 import json
+import random
 
 def hex_to_decimal(hex_color):
     r = int(hex_color[0:2], 16)
@@ -9,9 +10,18 @@ def hex_to_decimal(hex_color):
 
     return r, g, b
 
+
+def get_random_color_rgb():
+    r = random.randint(0, 255)
+    g = random.randint(0, 255)
+    b = random.randint(0, 255)
+
+    return r, g, b
+
+
 def write_settings_to_file(device, effect="", color="", dpi="", brightness=""):
     """ Save settings to a file for possible later retrieval """
-    
+
     home_dir = os.path.expanduser("~")
     dir_name = settings.CACHE_DIR
     file_name = settings.CACHE_FILE

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ LONG_DESC = open('README.md').read()
 
 setuptools.setup(
     name="razer-cli",
-    version="1.2",
+    version="1.3",
     author="Lorenz Leitner",
     author_email="lrnz.ltnr@gmail.com",
     description="Control Razer devices from the command line",


### PR DESCRIPTION
`razer-cli -e multicolor` for random colors.
`razer-cli -e multicolor ff0000 00ff00 0000ff` to supply colors.

These colors are spread across the keyboard / mouse.

Easy scriptability with e.g. `watch -n1 razer-cli -e multicolor` for animation.

Related to #25 