### PR TITLE
X resources palette as multicolor colors

### DIFF
--- a/razer_cli/razer_cli/handler/color_effect_handler.py
+++ b/razer_cli/razer_cli/handler/color_effect_handler.py
@@ -10,7 +10,7 @@ class ColorEffectHandler(Handler):
         if self.args.color:
             color = parse_color(self.args.color, self.args)
         elif self.args.automatic:
-            color = [util.get_x_color(self.args.verbose)]
+            color = [util.get_x_color(verbose=self.args.verbose)]
         zones = parse_zones(self.args.zones)
         if not self.args.effect:
             effects = ['static']

--- a/razer_cli/razer_cli/man_pages/effect
+++ b/razer_cli/razer_cli/man_pages/effect
@@ -25,9 +25,10 @@ The following effects support a second argument by adding a comma followed by a 
     wave,[1-2]
         1 = right and 2 = left
         If not specified it will be chosen at random
-    multicolor,[0-∞]
+    multicolor,[0-∞]|[xpalette]
         0 = assign random colors for everything (does not consume colors)
         1-∞ = the number of colors to use from -c
+        xpalette = chooses 16 colors from the Xresources (e.g. usage with pywal)
         This defaults to 0
     The following effects do NOT consume colors:
         none, active, brightness, breath_random, spectrum, starlight_random, and wave If you only specify 1 effect it will be applied all zone

--- a/razer_cli/razer_cli/parser/color_parser.py
+++ b/razer_cli/razer_cli/parser/color_parser.py
@@ -34,7 +34,7 @@ def parse_color(color, args: Namespace):
         # Use X colors as fallback if no color argument is set
         # TODO: Maybe also add argument to pull colors from
         # ~/.cache/wal.colors.jason
-        RGB.append(util.get_x_color(args.verbose))
+        RGB.append(util.get_x_color(verbose=args.verbose))
 
     return RGB
 
@@ -46,7 +46,7 @@ def parse_color_argument(color, args: Namespace):
         if rgb == "random":
             rgb = util.get_random_color_rgb()
         elif rgb == "x":
-            rgb = util.get_x_color(args.verbose)
+            rgb = util.get_x_color(verbose=args.verbose)
         else:
             rgb = util.hex_to_decimal(rgb)
     else:

--- a/razer_cli/razer_cli/setter/color_effect_setter.py
+++ b/razer_cli/razer_cli/setter/color_effect_setter.py
@@ -212,8 +212,15 @@ class ColorEffectSetter(Setter):
                     if self.args.verbose:
                         debug_msg[zone].append(["Setting", effect, 'to', b])
                 elif effect == 'multicolor':
+                    xpalette = False
                     if len(arg) > 0:
-                        used = int(arg[0])
+                        try:
+                            # This should be renamed from 'used'
+                            # Someone contributed this so I CBA'd to change it
+                            used = int(arg[0])
+                        except ValueError:
+                            used = 0
+                            xpalette = True
                     else:
                         used = 0
                     while len(color) < c_used + used:
@@ -221,8 +228,11 @@ class ColorEffectSetter(Setter):
                     cols = prop.advanced.cols
                     rows = prop.advanced.rows
                     if used == 0:
-                        colors_to_dist = [
-                            util.get_random_color_rgb() for _ in range(cols * rows)]
+                        if xpalette:
+                            colors_to_dist = util.get_x_colors(verbose=self.args.verbose)
+                        else:
+                            colors_to_dist = [
+                                util.get_random_color_rgb() for _ in range(cols * rows)]
                     else:
                         colors_to_dist = []
                         end = len(color)

--- a/razer_cli/razer_cli/setter/color_effect_setter.py
+++ b/razer_cli/razer_cli/setter/color_effect_setter.py
@@ -76,7 +76,7 @@ class ColorEffectSetter(Setter):
                         color = parse_color(
                             util.bytes_array_to_hex_array(getattr(prop, 'colors')), self.args)
                     except:
-                        color = [util.get_x_color(self.args.verbose)]
+                        color = [util.get_x_color(verbose=self.args.verbose)]
                     c_used = 0
                     if self.args.verbose:
                         debug_msg[zone].append(["No color given, using:", color])

--- a/razer_cli/tests/test_util.py
+++ b/razer_cli/tests/test_util.py
@@ -66,6 +66,14 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(0 <= green <= 255)
         self.assertTrue(0 <= blue <= 255)
 
+    def test_x_color(self) -> None:
+        color = util.get_x_color()
+        self.assertEqual(3, len(color))
+
+    def test_x_colors(self) -> None:
+        colors = util.get_x_colors()
+        self.assertEqual(16, len(colors))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`wal --theme random && razer-cli -e multicolor,xpalette`, for example, sets the colors of `multicolor` to the 16 colors defined in the X resources. This plays nicely with wal, similarly to `-a`, but it generates an entire palette.