### PR TITLE
Add check for get_low_battery_threshold capability

### DIFF
--- a/razer_cli/razer_cli/lister/device_lister.py
+++ b/razer_cli/razer_cli/lister/device_lister.py
@@ -46,9 +46,11 @@ class DeviceLister(Lister):
                     print("   battery:")
                     print("      charge:", device.battery_level)
                     print("      charging:", device.is_charging)
-                    print("      low threshold:",
-                          device.get_low_battery_threshold(), '%')
-                    print("      idle delay", device.get_idle_time(), 'seconds')
+                    if device.has('get_low_battery_threshold'):
+                        print("      low threshold:",
+                              device.get_low_battery_threshold(), '%')
+                    if device.has('get_idle_time'):
+                        print("      idle delay", device.get_idle_time(), 'seconds')
 
                 for i in settings.ZONES:
                     # Settings


### PR DESCRIPTION
Not every device that has "battery" capability also supports the get_low_battery_threshold method. This capability must be explicitly checked, so I've added the check for this method as well as for get_idle_time. You can see how capabilities are set in openrazer here:
https://github.com/openrazer/openrazer/blob/43b4a605e84f7530d8763a804eb875936e7bd5d7/pylib/openrazer/client/devices/__init__.py#L50

See issues:
https://github.com/LoLei/razer-cli/issues/66
https://github.com/LoLei/razer-cli/issues/70

Tested on Viper Ultimate. Needs testing on a device that does support the two above methods.