### PR TITLE
Fix active arg parsing

### DIFF
--- a/razer_cli/razer_cli/setter/color_effect_setter.py
+++ b/razer_cli/razer_cli/setter/color_effect_setter.py
@@ -207,7 +207,7 @@ class ColorEffectSetter(Setter):
                     if len(arg) == 0:
                         b = True
                     else:
-                        b = bool(arg[0])
+                        b = bool(int(arg[0]))
                     prop.active = b
                     if self.args.verbose:
                         debug_msg[zone].append(["Setting", effect, 'to', b])


### PR DESCRIPTION
`arg` is the string with the value passed for the active effect. Calling `bool()` on a non-empty string always returns `True`. As a result calling `razer-cli -e active,0` sets the device as active instead of inactive.
This commit fixes that by converting the arg to an integer before calling `bool()` on it.