### PR TITLE
Fix Github workflow

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [3.6]
+        python-version: ['3.x']
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Update python version as well as actions versions

Here's the successful run of the workflow https://github.com/romainrichard/razer-cli/actions/runs/8417847009

I also saw that `flake8` showed a bunch of errors, instead of completely ignoring them in the workflow it would be better to explicitly silence them in the code (adding `# noqa: C901` on the lines that flake8 flags), or even better fixing those issues when possible. Didn't want to overload this PR so left it as is.