### PR TITLE
Fix type annotations and call site inconsistencies.

### DIFF
--- a/razer_cli/razer_cli/handler/brightness_handler.py
+++ b/razer_cli/razer_cli/handler/brightness_handler.py
@@ -3,6 +3,8 @@ from razer_cli.razer_cli.handler.handler import Handler
 
 class BrightnessHandler(Handler):
     def handle(self):
+        assert self.setter is not None
+
         i = len(self.args.brightness)
         if i == 1 and self.args.brightness[0].isnumeric():
             self.args.brightness = {"all": self.args.brightness[0]}

--- a/razer_cli/razer_cli/handler/color_effect_handler.py
+++ b/razer_cli/razer_cli/handler/color_effect_handler.py
@@ -6,6 +6,8 @@ from razer_cli.razer_cli.parser.zone_parser import parse_zones
 
 class ColorEffectHandler(Handler):
     def handle(self):
+        assert self.setter is not None
+
         color = []
         if self.args.color:
             color = parse_color(self.args.color, self.args)

--- a/razer_cli/razer_cli/handler/handler.py
+++ b/razer_cli/razer_cli/handler/handler.py
@@ -3,12 +3,12 @@ from argparse import Namespace
 
 from openrazer.client import DeviceManager
 
+from typing import Optional
 from razer_cli.razer_cli.setter.setter import Setter
 
 
 class Handler(ABC):
-
-    def __init__(self, device_manager: DeviceManager, args: Namespace, version: str = None, setter: Setter = None):
+    def __init__(self, device_manager: DeviceManager, args: Namespace, version: Optional[str] = None, setter: Optional[Setter] = None):
         self.device_manager = device_manager
         self.args = args
         self.version = version

--- a/razer_cli/razer_cli/setter/battery_setter.py
+++ b/razer_cli/razer_cli/setter/battery_setter.py
@@ -6,7 +6,7 @@ from razer_cli.razer_cli.setter.setter import Setter
 
 class BatterySetter(Setter):
 
-    def set(self):
+    def set(self, **unused):
         for device in self.device_manager.devices:
             if (self.args.device and (device.name in self.args.device or device.serial in self.args.device)) or (not self.args.device):
                 if device.has("battery"):

--- a/razer_cli/razer_cli/setter/brightness_setter.py
+++ b/razer_cli/razer_cli/setter/brightness_setter.py
@@ -6,7 +6,7 @@ from razer_cli.razer_cli.setter.setter import Setter
 
 class BrightnessSetter(Setter):
 
-    def set(self):
+    def set(self, **unused):
         # Iterate over each device and set DPI
         for device in self.device_manager.devices:
             # If -d argument is set, only set those devices

--- a/razer_cli/razer_cli/setter/color_effect_setter.py
+++ b/razer_cli/razer_cli/setter/color_effect_setter.py
@@ -26,8 +26,7 @@ class ColorEffectSetter(Setter):
         #    pulsate, spectrum, starlight_dual, starlight_random,
         #    starlight_single, static, wave
 
-        if self.args.verbose:
-            debug_msg = {}
+        debug_msg = {}
         og_color_len = len(color)
         c_used = 0
         i = 0

--- a/razer_cli/razer_cli/setter/dpi_setter.py
+++ b/razer_cli/razer_cli/setter/dpi_setter.py
@@ -5,7 +5,7 @@ from razer_cli.razer_cli.setter.setter import Setter
 
 
 class DpiSetter(Setter):
-    def set(self):
+    def set(self, **unused):
         # Iterate over each device and set DPI
         for device in self.device_manager.devices:
             # If -d argument is set, only set those devices

--- a/razer_cli/razer_cli/setter/poll_rate_setter.py
+++ b/razer_cli/razer_cli/setter/poll_rate_setter.py
@@ -6,7 +6,7 @@ from razer_cli.razer_cli.setter.setter import Setter
 
 class PollRateSetter(Setter):
 
-    def set(self):
+    def set(self, **unused):
         # Iterate over each device and set Polling Rate
         for device in self.device_manager.devices:
             # If -d argument is set, only set those devices

--- a/razer_cli/razer_cli/util.py
+++ b/razer_cli/razer_cli/util.py
@@ -62,7 +62,7 @@ def get_random_color_rgb():
     return [r, g, b]
 
 
-def rgb_support(device, zone=False, effect=False):
+def rgb_support(device, zone=None, effect=None):
     prop = ["lighting"]
     if not device.capabilities[prop[0]]:
         # A Razer product without RGB? Does such a thing exist?
@@ -71,11 +71,11 @@ def rgb_support(device, zone=False, effect=False):
                 ] and not prop[0] + '_' + zone in device.capabilities:
         prop.append('scroll')
     elif zone and not zone == 'generic':
-        prop.append(zone)
+        prop.append(str(zone))
     if effect == 'advanced' or effect in settings.CUSTOM_EFFECTS:
         prop.append('led_matrix')
     elif effect:
-        prop.append(effect)
+        prop.append(str(effect))
     prop = '_'.join(prop)
     if prop in device.capabilities and device.capabilities[prop]:
         return True


### PR DESCRIPTION
With type annotations in the project, it helps to use them consistently. :+1:
