### PR TITLE
FIX: Handle empty config cache file to prevent JSONDecodeError

### DIFF
--- a/razer_cli/razer_cli/util.py
+++ b/razer_cli/razer_cli/util.py
@@ -177,7 +177,7 @@ def write_settings_to_file(device,
     path_and_file = os.path.join(home_dir, dir_name, file_name)
 
     # Handle non-existing file
-    if not os.path.isfile(path_and_file):
+    if not os.path.isfile(path_and_file) or os.path.getsize(path_and_file) == 0:
         os.makedirs(os.path.dirname(path_and_file), exist_ok=True)
         print("creating path and file")
         a = []


### PR DESCRIPTION
If the settings cache file (`razer-cli-settings.json`) is somehow empty (e.g. due to a crash or an interrupted write), the `write_settings_to_file` function crashes to `JSONDecodeError: Expecting Value`.

This PR adds a check using `os.path.getsize()` to ensure that if the file is empty, it gets properly re-initialized with an empty array `[]` instead of crashing.