### PR TITLE
Fix installation on arch linux

### DIFF
--- a/razer_cli/tests/test_util.py
+++ b/razer_cli/tests/test_util.py
@@ -1,11 +1,11 @@
 """Test util functions"""
 import json
 import os.path
-import shutil
+import tempfile
 import unittest
 # from openrazer.client import DeviceManager
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from razer_cli.razer_cli import settings, util
 
@@ -16,37 +16,30 @@ class TestUtil(unittest.TestCase):
     def test_write_settings_to_file(self):
         """> Test if cache file writing works"""
 
-        # Build file path
-        home_dir = os.path.expanduser("~")
-        dir_name = settings.CACHE_DIR
-        file_name = settings.CACHE_FILE
-        path_and_file = os.path.join(home_dir, dir_name, file_name)
+        with tempfile.TemporaryDirectory() as tmp_home:
+            with patch("razer_cli.razer_cli.util.os.path.expanduser",
+                       return_value=tmp_home):
+                # Build file path
+                dir_name = settings.CACHE_DIR
+                file_name = settings.CACHE_FILE
+                path_and_file = os.path.join(tmp_home, dir_name, file_name)
 
-        # Backup original file if this is running locally
-        if Path(path_and_file).exists():
-            shutil.copyfile(path_and_file, path_and_file + "_backup")
+                # Save random device settings to cache
+                device = MagicMock()
+                device.name = "test_device"
+                device.serial = "test_serial"
+                util.write_settings_to_file(device, dpi="1234")
+                util.write_settings_to_file(device, effect=["multicolor"])
 
-        # Save random device settings to cache
-        device = MagicMock()
-        device.name = "test_device"
-        device.serial = "test_serial"
-        util.write_settings_to_file(device, dpi="1234")
-        util.write_settings_to_file(device, effect=["multicolor"])
+                # Check if file has been written
+                self.assertTrue(os.path.isfile(path_and_file))
 
-        # Check if file has been written
-        self.assertTrue(os.path.isfile(path_and_file))
-
-        # Check contents
-        data = json.loads(Path(path_and_file).read_text())[0]
-        self.assertEqual(data["device_name"], "test_device")
-        self.assertEqual(data["serial"], "test_serial")
-        self.assertEqual(data["dpi"], "1234")
-        self.assertEqual(data["effect"], ["multicolor"])
-
-        # Restore original file
-        if Path(path_and_file + "_backup").exists():
-            shutil.copyfile(path_and_file + "_backup", path_and_file)
-            Path(path_and_file + "_backup").unlink()
+                # Check contents
+                data = json.loads(Path(path_and_file).read_text())[0]
+                self.assertEqual(data["device_name"], "test_device")
+                self.assertEqual(data["serial"], "test_serial")
+                self.assertEqual(data["dpi"], "1234")
+                self.assertEqual(data["effect"], ["multicolor"])
 
     def test_hex_to_decimal(self):
         """> Test if hex converting works"""


### PR DESCRIPTION
When installing via AUR, it runs the tests.

This breaks if there's existing config for the user already.

Override the environment so that tests have a unique directory for storing their config while testing.